### PR TITLE
Api cleaup

### DIFF
--- a/src/factory.jl
+++ b/src/factory.jl
@@ -325,10 +325,6 @@ immutable FunctionFactory{T1<:ArgType,T2<:ParamType,T3<:Associative,T4<:Type}
         _f(x) = _to_expr(csubs(normalize(x, targets=targets), def_map))
         normalized_eqs = [_f(eq) for eq in eqs]
 
-        # now filter args  and keep only those that actually appear in the
-        # equations
-        args = filter_args(args, incidence)
-
         new(normalized_eqs, args, params, targets, defs, funname, dispatch,
             incidence)
     end

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -102,45 +102,45 @@ end
 
 @testset "Dolang.time_shift" begin
     defs = Dict(:a=>:(b(-1)/c))
-    vars = [:c]
     funcs = [:foobar]
     for shift in [-1, 0, 1]
-        have = Dolang.time_shift(:(a+b(1) + c), shift)
+        have = Dolang.time_shift(:(a+b(1) + c), shift, variables=[:b])
         @test have == :(a+b($(shift+1)) + c)
 
         # with variables
-        have = Dolang.time_shift(:(a+b(1) + c), shift, variables=vars)
+        have = Dolang.time_shift(:(a+b(1) + c), shift, variables=[:b, :c])
         @test have == :(a+b($(shift+1)) + c($shift))
 
         # with defs
-        have = Dolang.time_shift(:(a+b(1) + c), shift, defs=defs)
+        have = Dolang.time_shift(:(a+b(1) + c), shift, defs=defs, variables=[:b])
         @test have == :(b($(shift-1))/c + b($(shift+1)) + c)
 
         # with defs + variables
         have = Dolang.time_shift(:(a+b(1) + c), shift,
-                                 defs=defs, variables=vars)
+                                 defs=defs, variables=[:b, :c])
         @test have == :(b($(shift-1))/c($(shift)) + b($(shift+1)) + c($(shift)))
 
         # unknown function
         @test_throws Dolang.UnknownFunctionError Dolang.time_shift(:(a+b(1) + foobar(c)), shift)
 
         # with functions
-        have = Dolang.time_shift(:(a+b(1) + foobar(c)), shift, functions=funcs)
+        have = Dolang.time_shift(:(a+b(1) + foobar(c)), shift, functions=funcs,
+                                 variables=[:b])
         @test have == :(a+b($(shift+1)) + foobar(c))
 
         # functions + defs
-        have = Dolang.time_shift(:(a+b(1) + foobar(c)), shift,
+        have = Dolang.time_shift(:(a+b(1) + foobar(c)), shift, variables=[:b],
                                  defs=defs, functions=funcs)
         @test have == :(b($(shift-1))/c + b($(shift+1)) + foobar(c))
 
         # functions + variables
-        have = Dolang.time_shift(:(a+b(1) + foobar(c)), shift,
-                                 variables=vars, functions=funcs)
+        have = Dolang.time_shift(:(a+b(1) + foobar(c)), shift, variables=[:b],
+                                 variables=[:b, :c], functions=funcs)
         @test have == :(a+b($(shift+1)) + foobar(c($shift)))
 
         # functions + variables + defs
         have = Dolang.time_shift(:(a+b(1) + foobar(c)), shift,
-                                 variables=vars, functions=funcs,
+                                 variables=[:b, :c], functions=funcs,
                                  defs=defs)
         want = :(b($(shift-1))/c($(shift)) + b($(shift+1)) + foobar(c($(shift))))
         @test have == want


### PR DESCRIPTION
@albop I have made some changes to clean up the API in Dolang.jl

Specifically, I have done the following:

- `make_method` no longer accepts `Der{n}` as the first argument. Instead all methods of that function accept a keyword argument `orders` that can either be an integer or list of integers specifying which order of derivatives you would like to get the Julia Expr for. This should close #10 -
- I no longer filter the user-supplied arguments to retain only those that actually appear. Instead, I keep all arguments the user gave in the compiled function arguments.
- I have a tentative version of building vectorized functions. Right now it only works for functions with a single argument vector, plus parameter vector (Dynare style) and only works for evaluating 0th order derivatives (levels). It simply adds a type annotation `::AbstractMatrix` to the single argument containing variables and then calls the non-vectorized version of the function in a loop to populate an output matrix. It isn't hooked up with `make_method` or anything else, you need to call `Dolang.build_vectorized_function(ff::FunctionFactory, Der{0})` to get the code. 