### PR TITLE
Sl/custom normalize

### DIFF
--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -28,9 +28,8 @@ Normalize the string or symbol in the following way:
 - if `n < 0` return `_var_mn_`
 
 """
-function normalize(var::Union{String,Symbol}, n::Integer)
-    n == 0 && return normalize(var)
-    Symbol(string("_", var, "_", n > 0 ? "_" : "m", abs(n)), "_")
+function normalize(var::Union{String,Symbol}, n::Integer; custom=nothing)
+    Symbol(string("_", var, "_", n >= 0 ? "_" : "m", abs(n)), "_")
 end
 
 """

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -111,7 +111,13 @@ function normalize(
 
 
     if ex.head == :block
+        # for 0.5
         if length(ex.args) == 2 && isa(ex.args[1], LineNumberNode)
+            return recur(ex.args[2])
+        end
+
+        # for 0.6
+        if length(ex.args) == 2 && isa(ex.args[1], Expr) && ex.args[1].head == :line
             return recur(ex.args[2])
         end
 

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -10,7 +10,7 @@ end
 function NormalizeError(ex::Expr)
     msg = """Dolang does not know how to normalize
     \t$(ex)
-    Perhaps you want ot use the keyword arugment `custom` when calling normalize?
+    Perhaps you want to use the keyword arugment `custom` when calling normalize?
     """
     NormalizeError(ex, msg)
 end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -1,6 +1,6 @@
 @testset "compiler" begin
 
-eqs = [:(foo = log(a)+b/x(-1)), :(bar = c(1)+u*d(1))]
+eqs = [:(foo = log(a(0))+b(0)/x(-1)), :(bar = c(1)+u*d(1))]
 args = [(:a, -1), (:a, 0), (:b, 0), (:c, 0), (:c, 1), (:d, 1)]
 params = [:u]
 defs = Dict(:x=>:(a/(1-c(1))))
@@ -70,7 +70,7 @@ end
     have = Dolang.equation_block(ff)
     @test have.head == :block
     @test length(have.args) == 4
-    @test have.args[1] == :(_foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_)))
+    @test have.args[1] == :(_foo_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_)))
     @test have.args[2] == :(_bar_ = _c__1_ + _u_ * _d__1_)
     @test have.args[3] == :(Dolang._assign_var(out, _foo_, 1))
     @test have.args[4] == :(Dolang._assign_var(out, _bar_, 2))
@@ -80,7 +80,7 @@ end
     @test have.head == :block
     @test length(have.args) == 2
 
-    ex1 = :(log(_a_) + _b_ / (_a_m1_ / (1 - _c_)) - _foo_)
+    ex1 = :(log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_)) - _foo_)
     ex2 = :(_c__1_ + _u_ * _d__1_ - _bar_)
     @test have.args[1] == :(Dolang._assign_var(out, $ex1, 1))
     @test have.args[2] == :(Dolang._assign_var(out, $ex2, 2))
@@ -135,14 +135,14 @@ end
                 end
                 begin
                     _a_m1_ = Dolang._unpack_var(V,1)
-                    _a_ = Dolang._unpack_var(V,2)
-                    _b_ = Dolang._unpack_var(V,3)
-                    _c_ = Dolang._unpack_var(V,4)
+                    _a__0_ = Dolang._unpack_var(V,2)
+                    _b__0_ = Dolang._unpack_var(V,3)
+                    _c__0_ = Dolang._unpack_var(V,4)
                     _c__1_ = Dolang._unpack_var(V,5)
                     _d__1_ = Dolang._unpack_var(V,6)
                 end
                 begin
-                    _foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_))
+                    _foo_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_))
                     _bar_ = _c__1_ + _u_ * _d__1_
                     Dolang._assign_var(out,_foo_,1)
                     Dolang._assign_var(out,_bar_,2)
@@ -158,14 +158,14 @@ end
                 end
                 begin
                     _a_m1_ = Dolang._unpack_var(V,1)
-                    _a_ = Dolang._unpack_var(V,2)
-                    _b_ = Dolang._unpack_var(V,3)
-                    _c_ = Dolang._unpack_var(V,4)
+                    _a__0_ = Dolang._unpack_var(V,2)
+                    _b__0_ = Dolang._unpack_var(V,3)
+                    _c__0_ = Dolang._unpack_var(V,4)
                     _c__1_ = Dolang._unpack_var(V,5)
                     _d__1_ = Dolang._unpack_var(V,6)
                 end
                 begin
-                    _foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_))
+                    _foo_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_))
                     _bar_ = _c__1_ + _u_ * _d__1_
                     Dolang._assign_var(out,_foo_,1)
                     Dolang._assign_var(out,_bar_,2)
@@ -210,14 +210,14 @@ end
                 end
                 begin
                     _a_m1_ = Dolang._unpack_var(V,1)
-                    _a_ = Dolang._unpack_var(V,2)
-                    _b_ = Dolang._unpack_var(V,3)
-                    _c_ = Dolang._unpack_var(V,4)
+                    _a__0_ = Dolang._unpack_var(V,2)
+                    _b__0_ = Dolang._unpack_var(V,3)
+                    _c__0_ = Dolang._unpack_var(V,4)
                     _c__1_ = Dolang._unpack_var(V,5)
                     _d__1_ = Dolang._unpack_var(V,6)
                 end
                 begin
-                    _foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_))
+                    _foo_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_))
                     _bar_ = _c__1_ + _u_ * _d__1_
                     Dolang._assign_var(out,_foo_,1)
                     Dolang._assign_var(out,_bar_,2)
@@ -239,14 +239,14 @@ end
                 end
                 begin
                     _a_m1_ = Dolang._unpack_var(V,1)
-                    _a_ = Dolang._unpack_var(V,2)
-                    _b_ = Dolang._unpack_var(V,3)
-                    _c_ = Dolang._unpack_var(V,4)
+                    _a__0_ = Dolang._unpack_var(V,2)
+                    _b__0_ = Dolang._unpack_var(V,3)
+                    _c__0_ = Dolang._unpack_var(V,4)
                     _c__1_ = Dolang._unpack_var(V,5)
                     _d__1_ = Dolang._unpack_var(V,6)
                 end
                 begin
-                    _foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_))
+                    _foo_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_))
                     _bar_ = _c__1_ + _u_ * _d__1_
                     Dolang._assign_var(out,_foo_,1)
                     Dolang._assign_var(out,_bar_,2)
@@ -297,14 +297,14 @@ end
                 end
                 begin
                     _a_m1_ = Dolang._unpack_var(V,1)
-                    _a_ = Dolang._unpack_var(V,2)
-                    _b_ = Dolang._unpack_var(V,3)
-                    _c_ = Dolang._unpack_var(V,4)
+                    _a__0_ = Dolang._unpack_var(V,2)
+                    _b__0_ = Dolang._unpack_var(V,3)
+                    _c__0_ = Dolang._unpack_var(V,4)
                     _c__1_ = Dolang._unpack_var(V,5)
                     _d__1_ = Dolang._unpack_var(V,6)
                 end
                 begin
-                    _foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_))
+                    _foo_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_))
                     _bar_ = _c__1_ + _u_ * _d__1_
                     Dolang._assign_var(out,_foo_,1)
                     Dolang._assign_var(out,_bar_,2)
@@ -320,14 +320,14 @@ end
                 end
                 begin
                     _a_m1_ = Dolang._unpack_var(V,1)
-                    _a_ = Dolang._unpack_var(V,2)
-                    _b_ = Dolang._unpack_var(V,3)
-                    _c_ = Dolang._unpack_var(V,4)
+                    _a__0_ = Dolang._unpack_var(V,2)
+                    _b__0_ = Dolang._unpack_var(V,3)
+                    _c__0_ = Dolang._unpack_var(V,4)
                     _c__1_ = Dolang._unpack_var(V,5)
                     _d__1_ = Dolang._unpack_var(V,6)
                 end
                 begin
-                    _foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_))
+                    _foo_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_))
                     _bar_ = _c__1_ + _u_ * _d__1_
                     Dolang._assign_var(out,_foo_,1)
                     Dolang._assign_var(out,_bar_,2)
@@ -371,14 +371,14 @@ end
                 end
                 begin
                     _a_m1_ = Dolang._unpack_var(V,1)
-                    _a_ = Dolang._unpack_var(V,2)
-                    _b_ = Dolang._unpack_var(V,3)
-                    _c_ = Dolang._unpack_var(V,4)
+                    _a__0_ = Dolang._unpack_var(V,2)
+                    _b__0_ = Dolang._unpack_var(V,3)
+                    _c__0_ = Dolang._unpack_var(V,4)
                     _c__1_ = Dolang._unpack_var(V,5)
                     _d__1_ = Dolang._unpack_var(V,6)
                 end
                 begin
-                    _foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_))
+                    _foo_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_))
                     _bar_ = _c__1_ + _u_ * _d__1_
                     Dolang._assign_var(out,_foo_,1)
                     Dolang._assign_var(out,_bar_,2)
@@ -400,14 +400,14 @@ end
                 end
                 begin
                     _a_m1_ = Dolang._unpack_var(V,1)
-                    _a_ = Dolang._unpack_var(V,2)
-                    _b_ = Dolang._unpack_var(V,3)
-                    _c_ = Dolang._unpack_var(V,4)
+                    _a__0_ = Dolang._unpack_var(V,2)
+                    _b__0_ = Dolang._unpack_var(V,3)
+                    _c__0_ = Dolang._unpack_var(V,4)
                     _c__1_ = Dolang._unpack_var(V,5)
                     _d__1_ = Dolang._unpack_var(V,6)
                 end
                 begin
-                    _foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_))
+                    _foo_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_))
                     _bar_ = _c__1_ + _u_ * _d__1_
                     Dolang._assign_var(out,_foo_,1)
                     Dolang._assign_var(out,_bar_,2)

--- a/test/factory.jl
+++ b/test/factory.jl
@@ -156,7 +156,7 @@ end
         ff = _FF(eqs, args, params, targets=targets, defs=defs, funname=funname)
 
         # test that equations were normalized properly
-        norm_eq1 = :(_foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c_)))
+        norm_eq1 = :(_foo_ = log(_a_) + _b_ / (_a_m1_ / (1 - _c__0_)))
         norm_eq2 = :(_bar_ = _c__1_ + _u_ * _d__1_)
         norm_eq = [norm_eq1, norm_eq2]
         @test ff.eqs == norm_eq

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -8,17 +8,17 @@ end
 
 @testset "Dolang.normalize" begin
     @testset "Dolang.normalize(::Union{Symbol,String}, Integer)" begin
-        @test Dolang.normalize(:x, 0) == :_x_
+        @test Dolang.normalize(:x, 0) == :_x__0_
         @test Dolang.normalize(:x, 1) == :_x__1_
         @test Dolang.normalize(:x, -1) == :_x_m1_
         @test Dolang.normalize(:x, -100) == :_x_m100_
 
-        @test Dolang.normalize("x", 0) == :_x_
+        @test Dolang.normalize("x", 0) == :_x__0_
         @test Dolang.normalize("x", 1) == :_x__1_
         @test Dolang.normalize("x", -1) == :_x_m1_
         @test Dolang.normalize("x", -100) == :_x_m100_
 
-        @test Dolang.normalize((:x, 0)) == :_x_
+        @test Dolang.normalize((:x, 0)) == :_x__0_
         @test Dolang.normalize((:x, 1)) == :_x__1_
         @test Dolang.normalize((:x, -1)) == :_x_m1_
         @test Dolang.normalize((:x, -100)) == :_x_m100_
@@ -43,9 +43,6 @@ end
             @test Dolang.normalize(string("x(", T(i), ")")) == Symbol("_x__$(i)_")
             @test Dolang.normalize(string("x(", T(-i), ")")) == Symbol("_x_m$(i)_")
         end
-
-        # only add underscore to naems when shift is 0
-        @test Dolang.normalize("x(0)") == :_x_
     end
 
     @testset "other function calls" begin
@@ -70,8 +67,8 @@ end
         end
 
         @testset "arithmetic" begin
-            @test Dolang.normalize(:(a(1) + b + c(2) + d(-1))) == :(((_a__1_ + _b_) + _c__2_) + _d_m1_)
-            @test Dolang.normalize(:(a(1) * b * c(2) * d(-1))) == :(((_a__1_ * _b_) * _c__2_) * _d_m1_)
+            @test Dolang.normalize(:(a(1) + b + c(2) + d(-1))) == :(_a__1_ + _b_ + _c__2_ + _d_m1_)
+            @test Dolang.normalize(:(a(1) * b * c(2) * d(-1))) == :(_a__1_ * _b_ * _c__2_ * _d_m1_)
             @test Dolang.normalize(:(a(1) - b - c(2) - d(-1))) == :(((_a__1_ - _b_) - _c__2_) - _d_m1_)
             @test Dolang.normalize(:(a(1) ^ b)) == :(_a__1_ ^ _b_)
         end
@@ -93,7 +90,7 @@ end
     end
 
     @testset "normalize(::Tuple{Symbol,Int})" begin
-        @test Dolang.normalize((:x, 0)) == :_x_
+        @test Dolang.normalize((:x, 0)) == :_x__0_
         @test Dolang.normalize((:x, 1)) == :_x__1_
         @test Dolang.normalize((:x, -1)) == :_x_m1_
         @test Dolang.normalize((:x, -100)) == :_x_m100_

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -120,7 +120,13 @@ end
 
         ex = :(a(1) + x[i](1) / b)
         want = :(_a__1_ + _x__i__1_ / _b_)
-        @test_throws MethodError Dolang.normalize(ex)
+        @test_throws Dolang.NormalizeError Dolang.normalize(ex)
+        try
+            Dolang.normalize(ex)
+        catch e
+            @test isa(e, Dolang.NormalizeError)
+            @test e.ex == :(x[i](1))
+        end
         @test Dolang.normalize(ex, custom=agent_time_normalizer) == want
 
         # test with target

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -95,6 +95,39 @@ end
         @test Dolang.normalize((:x, -1)) == :_x_m1_
         @test Dolang.normalize((:x, -100)) == :_x_m100_
     end
+
+    @testset "Custom normalizer" begin
+        function agent_time_normalizer(ex::Expr)
+            # matches var[inds](time)
+            if (ex.head == :call &&  # function matches ending `()`
+                length(ex.args) == 2 &&   # only one arg inside `()`
+                isa(ex.args[1], Expr) &&  # part before `()` is an expr
+                ex.args[1].head == :ref &&  # part before `()` is a `[]`
+                isa(ex.args[1].args[2], Union{Symbol, Number}) &&  # part in `[]` is scalar
+                isa(ex.args[2], Union{Symbol, Number})  # part in `()` is scalar
+                )
+                # have structure we want, just need to unpack it
+                var = ex.args[1].args[1]
+                ind = ex.args[1].args[2]
+                shift = ex.args[2]
+                return Nullable(
+                    Symbol("_$(var)__$(ind)", shift >= 0 ? "__" : "_m", abs(shift), "_")
+                    )
+            else
+                return Nullable{Symbol}()
+            end
+        end
+
+        ex = :(a(1) + x[i](1) / b)
+        want = :(_a__1_ + _x__i__1_ / _b_)
+        @test_throws MethodError Dolang.normalize(ex)
+        @test Dolang.normalize(ex, custom=agent_time_normalizer) == want
+
+        # test with target
+        ex = :(z(1) = a(1) + x[i](1) / b)
+        want = :(_a__1_ + _x__i__1_ / _b_ - _z__1_)
+        @test Dolang.normalize(ex, custom=agent_time_normalizer) == want
+    end
 end
 
 @testset "Dolang.time_shift" begin

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -2,8 +2,8 @@
 
 @testset "Dolang.eq_expr" begin
     ex = :(z = x + y(1))
-    @test Dolang.eq_expr(ex) == :(_x_ + _y__1_ - _z_)
-    @test Dolang.eq_expr(ex, [:z]) == :(_z_ = _x_ + _y__1_)
+    @test Dolang.normalize(ex) == :(_x_ + _y__1_ - _z_)
+    @test Dolang.normalize(ex, targets=[:z]) == :(_z_ = _x_ + _y__1_)
 end
 
 @testset "Dolang.normalize" begin


### PR DESCRIPTION
We need to provide a way for users to be able to extend Dolang's `normalize` function so that it works with custom subexpressions.

Right now, in order to do this the user would have to modify the method `normalize(::Expr)` found [here](https://github.com/EconForge/Dolang/blob/9218f96346f6c5d352e84a021db15427e8c00f3c/src/symbolic.jl#L79-L121) by adding more `if` blocks. This isn't very extensible.

Here's one proposal for how we can remedy this:

```julia
_empty_normalizer(e) = Nullable{Expr}()

function normalize(
        ex::Expr; targets::Union{Vector{Expr},Vector{Symbol}}=Symbol[],
        customr::Function=_empty_normalizer
    )
end
```

The `custom_normalizer` is a function that takes a single argument (most likely of type `Expr`) and returns an instance of `Base.Nullable`. The idea is that this function will try to match a sub-expression and return a normalized version of that expression. If a match is found then the `Nullable` will be non-empty. If a match was not found, then the Nullable will be empty. 

The `custom_normalizer` function will be called at the beginning of the `normalize(::Expr)` method linked to above -- giving the user's custom normalization routine precedence over the built-in Dolang normalization rules. If the `custom_normalizer` succeeds then we will return the corresponding output. If it fails then we fall through to Dolang's built in routines.

This is probably best understood by example.

Suppose we want to teach Dolang to normalize expressions that look like `x[i](t)`.

One `custom_normlizer` that would work, could be as follows

```julia
using MacroTools

function agent_time_normalizer(ex::Expr)
    @match ex begin
        x_[i_](t_) => Nullable(Symbol("_", x, "__", i, "__", t, "_"))
        _ => Nullable{Symbol}()
    end
end

# anything other type besides Expr should return an empty Nullable
agent_time_normalizer(x) = Nullable{Symbol}()
```

We can test it out to make sure it works

```
julia> agent_time_normalizer(:(x[1](4)))
Nullable{Symbol}(:_x__1__4)

julia> agent_time_normalizer(:(x[1](4, 3)))
Nullable{Symbol}()

julia> agent_time_normalizer(:(x[i](4)))
Nullable{Symbol}(:_x__i__4)

julia> agent_time_normalizer(:(x(1)[t]))
Nullable{Symbol}()

julia> agent_time_normalizer(1)
Nullable{Symbol}()

julia> agent_time_normalizer(:x)
Nullable{Symbol}()
```

Looks like it works!

Now suppose we have `ex = :(a(1) + x[i](1) / b)`

Given our new rule and Dolang's internal rules, the normalized version of this expression is `:(_a__1_ + _x__i__1_ / _b_)`

If we try Dolang's current `normalize` function on this, it fails:

```
julia> Dolang.normalize(ex)
ERROR: MethodError: no method matching normalize(::Expr, ::Int64)
Closest candidates are:
  normalize(::Expr; targets) at /Users/sglyon/.julia/v0.6/Dolang/src/symbolic.jl:80
  normalize(::AbstractArray{T,1} where T, ::Real) at linalg/generic.jl:1295
  normalize(::Union{String, Symbol}, ::Integer) at /Users/sglyon/.julia/v0.6/Dolang/src/symbolic.jl:32
Stacktrace:
 [1] #normalize#1(::Array{Symbol,1}, ::Function, ::Expr) at /Users/sglyon/.julia/v0.6/Dolang/src/symbolic.jl:100
 [2] normalize(::Expr) at /Users/sglyon/.julia/v0.6/Dolang/src/symbolic.jl:80
 [3] _collect(::Array{Any,1}, ::Base.Generator{Array{Any,1},Base.LinAlg.#normalize}, ::Base.EltypeUnknown, ::Base.HasShape) at ./array.jl:442
 [4] #normalize#1(::Array{Symbol,1}, ::Function, ::Expr) at /Users/sglyon/.julia/v0.6/Dolang/src/symbolic.jl:117
 [5] normalize(::Expr) at /Users/sglyon/.julia/v0.6/Dolang/src/symbolic.jl:80
 [6] call_plus_times_expr(::Expr) at /Users/sglyon/.julia/v0.6/Dolang/src/symbolic.jl:634
 [7] #normalize#1(::Array{Symbol,1}, ::Function, ::Expr) at /Users/sglyon/.julia/v0.6/Dolang/src/symbolic.jl:113
 [8] normalize(::Expr) at /Users/sglyon/.julia/v0.6/Dolang/src/symbolic.jl:80
```

If we try the extended one we get:

```
julia> Dolang.normalize(ex, custom=agent_time_normalizer)
:(_a__1_ + _x__i__1 / _b_)
```

## Feedback

This works, but I wanted to ask for feedback.

Is asking users to use `Nullable` too much? I think it is a nice way to convey that we either failed or succeeded and have a result, but I'd still like to see what others think.