### PR TITLE
Sl/assume sanitized

### DIFF
--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -428,7 +428,7 @@ Walk the expression and populate `out` according to the following rules for
 each type of subexpression encoutered:
 
 - `s::Symbol`: add `s` to `out[:parameters]`
-- `x(i::Integer)`: Add `(x, i)` out `out[:parameters]``
+- `x(i::Integer)`: Add `(x, i)` out `out[:variables]`
 - All other function calls: add any arguments to `out` according to above rules
 - Anything else: do nothing.
 """
@@ -454,6 +454,9 @@ function list_symbols!(out, ex::Expr, functions::Set{Symbol})
             throw(UnknownFunctionError(func, "Unknown function $func"))
         end
     end
+
+    # TODO: this is not flexible. It will completely skip over things like
+    #       b[i](t).
     out
 end
 
@@ -461,20 +464,20 @@ end
 # list_variables #
 # -------------- #
 
-# function list_variables(ex::Expr;
-#                       functions::Union{Set{Symbol},Vector{Symbol}}=Set{Symbol}(),
-#                       variables::Union{Set{Symbol},Vector{Symbol}}=Set{Symbol}())
-#     syms = list_symbols(ex; functions=functions, variables=variables)
-#     out = Set{Symbol}()
-#     for (k, v) in syms
-#         for sym in v
-#             isa(sym, Symbol) ? push!(out, sym) :
-#             isa(sym, Tuple{Symbol,Int}) ? push!(out, sym[1]):
-#             error("not sure what happened here")
-#         end
-#     end
-#     out
-# end
+function list_variables(
+        arg;
+        functions::Union{Set{Symbol},Vector{Symbol}}=Set{Symbol}()
+    )::Set{Tuple{Symbol,Int}}
+    list_symbols(arg, functions=functions)[:variables]
+end
+
+
+function list_parameters(
+        arg;
+        functions::Union{Set{Symbol},Vector{Symbol}}=Set{Symbol}()
+    )::Set{Symbol}
+    list_symbols(arg, functions=functions)[:parameters]
+end
 
 # ---- #
 # subs #

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -468,14 +468,14 @@ function list_symbols!(out, ex::Expr, functions::Set{Symbol},
                        variables::Set{Symbol})
     # here we just need to walk the expression tree and pull out symbols
     if is_time_shift(ex)
-        var = ex.args[1]
-        shift = ex.args[2]
+        var, shift = arg_name_time(ex)
         current = get!(out, :variables, Set{Tuple{Symbol,Int}}())
         push!(current, (var, shift))
         return out
     end
 
-    # if it is some kind of function call, steady_state arguments
+    # if it is some kind of function call, make sure we recognize it and throw
+    # errors otherwise
     if ex.head == :call
         func = ex.args[1]
         if func in DOLANG_FUNCTIONS || func in functions
@@ -687,9 +687,31 @@ end
 
 arg_name(s::Symbol) = s
 arg_name(s::Tuple{Symbol,Int}) = s[1]
+function arg_name(ex::Expr)::Symbol
+    if is_time_shift(ex)
+        return ex.args[1]
+    else
+        m = string(
+            "Expression $(ex) does not look like a variable. ",
+            "The only allowed expressions must satisfy `is_time_shift(ex)`"
+        )
+        error(m)
+    end
+end
 
 arg_time(s::Symbol) = 0
 arg_time(s::Tuple{Symbol,Int}) = s[2]
+function arg_time(ex::Expr)::Int
+    if is_time_shift(ex)
+        return ex.args[2]
+    else
+        m = string(
+            "Expression $(ex) does not look like a variable. ",
+            "The only allowed expressions must satisfy `is_time_shift(ex)`"
+        )
+        error(m)
+    end
+end
 
 arg_name_time(s) = (arg_name(s), arg_time(s))
 

--- a/test/factory.jl
+++ b/test/factory.jl
@@ -28,7 +28,7 @@ end
         :M => [(:c, 1), (:d, 1)]
     )
     params = [:u]
-    defs = Dict(:x=>:(a/(1-c(1))))
+    defs = Dict(:x=>:(a(0)/(1-c(1))))
     targets = [(:foo, 0), (:bar, 0)]
     funname = :myfun
     _FF = Dolang.FunctionFactory

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -197,16 +197,14 @@ end
 
 @testset "Dolang.list_symbols" begin
     out = Dolang.list_symbols(:(a+b(1)+c))
-    want = Set{Tuple{Symbol,Int}}(); push!(want, (:b, 1))
     @test haskey(out, :variables)
-    @test out[:variables] == want
+    @test out[:variables] == Set([(:b, 1)])
     @test haskey(out, :parameters)
     @test out[:parameters] == Set{Symbol}([:a, :c])
 
-    out = Dolang.list_symbols(:(a+b(1)+c), variables=[:c])
-    want = Set{Tuple{Symbol,Int}}(); push!(want, (:b, 1)); push!(want, (:c, 0))
+    out = Dolang.list_symbols(:(a+b(1)+c(0)))
     @test haskey(out, :variables)
-    @test out[:variables] == want
+    @test out[:variables] == Set([(:b, 1), (:c, 0)])
     @test haskey(out, :parameters)
     @test out[:parameters] == Set{Symbol}([:a])
 
@@ -215,9 +213,8 @@ end
 
     # now let the function be ok
     out = Dolang.list_symbols(:(a+b(1)+c + foobar(c)), functions=[:foobar])
-    want = Set{Tuple{Symbol,Int}}(); push!(want, (:b, 1))
     @test haskey(out, :variables)
-    @test out[:variables] == want
+    @test out[:variables] == Set([(:b, 1)])
     @test haskey(out, :parameters)
     @test out[:parameters] == Set{Symbol}([:a, :c])
 end

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -238,19 +238,21 @@ end
     want = :(python(faster + more, eats))
     @test Dolang.csubs(:(monty(run + eat, eats)), d) == want
 
-    d = Dict(:b => :(c + d(1)))
-    ex = :(a + b + b(1))
-    want = :(a + (c + d(1)) + b(1))
-    @test Dolang.csubs(ex, d) == want
+    for ex in [:(a + b(0) + b(1)), :(a + b + b(1))]
+        for key in [:b, (:b, 0)]
+            d = Dict(key => :(c(0) + d(1)))
+            want = :(a + (c(0) + d(1)) + (c(1) + d(2)))
+            @test Dolang.csubs(ex, d) == want
 
-    d = Dict((:b, 0) => :(c + d(1)))
-    ex = :(a + b + b(1))
-    want = :(a + (c + d(1)) + b(1))
-    @test Dolang.csubs(ex, d) == want
+            d = Dict(key => :(c + d(1)))
+            want = :(a + (c + d(1)) + (c + d(2)))
+            @test Dolang.csubs(ex, d) == want
+        end
+    end
 
-    d = Dict((:b, 0) => :(c + d(1)), (:b, 1) => :(c(1) + d(2)))
+    d = Dict((:b, 0) => :(c + d(1)), (:b, 1) => :(c(100) + d(2)))
     ex = :(a + b + b(1))
-    want = :(a + (c + d(1)) + (c(1) + d(2)))
+    want = :(a + (c + d(1)) + (c(100) + d(2)))
     @test Dolang.csubs(ex, d) == want
 
     # case where subs and csubs aren't the same

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -196,27 +196,37 @@ end
 end
 
 @testset "Dolang.list_symbols" begin
-    out = Dolang.list_symbols(:(a+b(1)+c))
+    ex = :(a+b(1)+c)
+    out = Dolang.list_symbols(ex)
     @test haskey(out, :variables)
     @test out[:variables] == Set([(:b, 1)])
     @test haskey(out, :parameters)
     @test out[:parameters] == Set{Symbol}([:a, :c])
+    @test out[:variables] == @inferred Dolang.list_variables(ex)
+    @test out[:parameters] == @inferred Dolang.list_parameters(ex)
 
-    out = Dolang.list_symbols(:(a+b(1)+c(0)))
+    ex = :(a+b(1)+c(0))
+    out = Dolang.list_symbols(ex)
     @test haskey(out, :variables)
     @test out[:variables] == Set([(:b, 1), (:c, 0)])
     @test haskey(out, :parameters)
     @test out[:parameters] == Set{Symbol}([:a])
+    @test out[:variables] == @inferred Dolang.list_variables(ex)
+    @test out[:parameters] == @inferred Dolang.list_parameters(ex)
 
     # Unknown function
     @test_throws Dolang.UnknownFunctionError Dolang.list_symbols(:(a+b(1)+c+foobar(c)))
 
     # now let the function be ok
-    out = Dolang.list_symbols(:(a+b(1)+c + foobar(c)), functions=[:foobar])
+    ex = :(a+b(1)+c + foobar(c))
+    out = Dolang.list_symbols(ex, functions=[:foobar])
     @test haskey(out, :variables)
     @test out[:variables] == Set([(:b, 1)])
     @test haskey(out, :parameters)
     @test out[:parameters] == Set{Symbol}([:a, :c])
+    @test out[:variables] == @inferred Dolang.list_variables(ex, functions=[:foobar])
+    @test out[:parameters] == @inferred Dolang.list_parameters(ex, functions=[:foobar])
+
 end
 
 @testset " csubs()" begin

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -281,11 +281,13 @@ end
             @test Dolang.arg_name((s, t)) == s
             @test Dolang.arg_time((s, t)) == t
             @test Dolang.arg_name_time((s, t)) == (s, t)
+            @test Dolang.arg_name(Expr(:call, s, t)) == s
+            @test Dolang.arg_time(Expr(:call, s, t)) == t
+            @test Dolang.arg_name_time(Expr(:call, s, t)) == (s, t)
         end
     end
 
     for f in (Dolang.arg_name, Dolang.arg_time, Dolang.arg_name_time, Dolang.arg_names)
-        @test_throws MethodError f(:(x(0)))  # Expr
         @test_throws MethodError f(1)        # Number
         @test_throws MethodError f([1])      # Array of number
     end


### PR DESCRIPTION
Ok so this PR made adjustments to src/symbolic.jl where throughout all the routines we assume that expressions have been sanitized.

This means that any symbol that appears by itself will be treated as a parameter. Things like `list_variables` and `time_shift` will not alter them.

Any expression that passes the test `Dolang.is_time_shift(ex)` will be treated as a dynamic variable

This simplifies things quite a bit -- especially in `subs` and `csubs`.  One inconsistency is that the keys for a definitions dict are allowed to be either `(symbol::symbol, time::Int)` or `symbol::Symbol`. If `(c?)subs` sees the `symbol::Symbol` version it treats it exactly the same as `(symbol::Symbol, 0)`.

Note that when using `(c?)subs` you now have to make sure that the values of the definitions dict are sanitized. For example

```
julia> Dolang.csubs(:(a + b(0) + b(1)), Dict((:b, 0) => :(c + d(1))))
:(a + (c + d(1)) + (c + d(2)))

julia> Dolang.csubs(:(a + b(0) + b(1)), Dict((:b, 0) => :(c(0) + d(1))))
:(a + (c(0) + d(1)) + (c(1) + d(2)))
```

Notice that in the first case `c` will be treated as a parameter and not time shifted, whereas in the second it is shifted.