### PR TITLE
Sl/smart generated funcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/*
 *.pyc
 *checkpoint*
 scratch.jl
+docs/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ notifications:
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Starboxes"); Pkg.test("Starboxes"; coverage=true)'
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Dolang"); Pkg.test("Dolang"; coverage=true)'
 after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("Starboxes")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("Starboxes")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'Pkg.add("Documenter")'
+  - julia -e 'cd(Pkg.dir("Dolang")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ notifications:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("Dolang"); Pkg.test("Dolang"; coverage=true)'
 after_success:
-  - julia -e 'Pkg.add("Documenter")'
+  - julia -e 'Pkg.add("Documenter"); Pkg.add("SymEngine")'
   - julia -e 'cd(Pkg.dir("Dolang")); include(joinpath("docs", "make.jl"))'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,35 @@
+try
+    Pkg.installed("SymEngine")
+catch
+    Pkg.add("SymEngine")
+end
+
+using Documenter, Dolang
+
+makedocs(
+    modules=[Dolang],
+    authors="Spencer Lyon, Pablo Winant, and contributors",
+    clean=false,
+    format=:html,
+    sitename="Dolang.jl",
+    doctest=true,
+    pages=[
+        "Guide" => [
+            "index.md",
+            "symbolic.md",
+            "compiler.md",
+            "examples.md",
+        ],
+        "Developer Documentation" => [
+            "dev/compiler.md"
+        ]
+    ],
+)
+
+deploydocs(
+    repo   = "github.com/EconForge/Dolang.jl.git",
+    julia  = "0.6",
+    target = "build",
+    deps   = nothing,
+    make   = nothing,
+)

--- a/docs/src/compiler.md
+++ b/docs/src/compiler.md
@@ -1,0 +1,31 @@
+# Dolang's compiler
+
+The second main component of Dolang is a compiler that leverages its [Symbolic
+manipulation](@ref) routines to produce efficient Julia functions to evaluate
+equations and systems of equations.
+
+## `FunctionFactory`
+
+The compiler mainly operates through one main type, the `FunctionFactory`.
+
+```@docs
+FunctionFactory
+```
+
+## `make_function`
+
+Once an instance of `FunctionFactory` is created, a single function is used to
+compile Julia a function with various methods for evaluating different orders of
+derivative of the factory's expressions. This function is named `make_function` and is called
+
+```@docs
+make_function(::FunctionFactory)
+```
+
+There is also a convenience method of `make_function` that takes built-in Julia
+objects as inputs, constructs the `FunctionFactory` for you, then calls the
+above method:
+
+```@docs
+make_function(::Vector{Expr}, ::AbstractVector, ::AbstractVector)
+```

--- a/docs/src/dev/compiler.md
+++ b/docs/src/dev/compiler.md
@@ -1,4 +1,9 @@
-# The Dolang.jl compiler
+# Compiler internals
+
+**NOTE: 2017-06-13**: These docs might be slightly out of date. They should
+still serve as a helpful reference if you are totally lost when reading the
+code, but the best way to understand what is going on is to read the code in
+`src/symbolic.jl` and `src/compiler.jl`
 
 These are some developer notes about the compiler inside Dolang.jl
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,0 +1,252 @@
+# Examples
+
+Let's show some examples of how use Dolang to compile simple Julia functions.
+
+## Basic example
+
+First, let's construct some equations, arguments, and parameters
+
+```@example ff1
+using Dolang
+eqs = [
+    :(foo(0) = log(a(0))+b(0)/x(-1)),
+    :(bar(0) = c(1)+u*d(1))
+]
+args = [(:a, -1), (:a, 0), (:b, 0), (:c, 0), (:c, 1), (:d, 1)]
+params = [:u]
+defs = Dict(:x=>:(a(0)/(1-c(1))))
+targets = [(:foo, 0), (:bar, 0)]
+
+ff = FunctionFactory(
+    eqs, args, params, targets=targets, defs=defs, funname=:myfun
+)
+```
+
+Now that we have our `FunctionFactory` we can generate some code (warning, the
+generated code is *not* pretty):
+
+```@example ff1
+code = make_function(ff)
+print(code) # hide
+```
+
+In order to actually call methods of `myfun` we need to call `eval` on our `code`:
+
+```@example ff1
+eval(code)
+```
+
+And now we can call it
+
+```@example ff1
+V = [1.5, 2.5, 1.0, 2.0, 3.0, 1.1]
+p = [0.5]
+myfun(V, p)
+```
+
+We can call the vectorized version:
+
+```@example ff1
+myfun([V V]', p)
+```
+
+Or the mutating one:
+
+```@example ff1
+out = zeros(2)
+myfun!(out, V, p)
+out
+```
+
+We can evaluate the Jacobian (first derivative matrix)
+
+```@example ff1
+myfun(Der{1}, V, p)
+```
+
+... or the Hessian
+
+```@example ff1
+myfun(Der{2}, V, p)
+```
+
+... or higher order derivatives
+
+```@example ff1
+myfun(Der{3}, V, p)
+```
+
+```@example ff1
+myfun(Der{10}, V, p)
+```
+
+Note that the Hessian is returned in as a `SparseMatrixCSC` where the columns
+are ordered with the first variable increasing faster. In this example, the
+`(1, 4)` element of the Hessian will be the second partial derivative of the
+first equation (the `1`) with fourth and first variables in `args`.
+
+For all higher order derivatives the return value is a
+`Vector{Dict{NTuple{N,Int}, Float64}}`, where `N` is the order of derivative.
+The keys of each dict will be non-increasing so mixed partials are only
+computed and stored once. Notice that for the order `3` derivatives an entry
+for `(1, 1, 3)` appears, but not for `(1, 3, 1)` or `(3, 1, 1)`. The user of
+these routines is required to handle the [equality of
+partials](https://calculus.subwiki.org/wiki/Clairaut%27s_theorem_on_equality_of_mixed_partials).
+
+## With `dispatch`
+
+Now lets consider an example that leverages the `dispatch` argument. In this
+case we will use the convenience method for make function with signature:
+[`make_function(::Vector{Expr}, ::AbstractVector, ::AbstractVector)`](@ref). We
+also will not show the compiled code
+
+```@example ff2
+using Dolang  # hide
+eqs = [
+    :(sin(x(0)) + exp(2*x(1))),
+    :(y(0) / (2 * (1 - β))),
+]
+# NOTE: Arguments can be pre-normalized and contain unicode
+variables = [(:x, 0), (:y, 0), :_x__1_, :β]  
+to_diff = 1:3
+code = make_function(eqs, variables, to_diff, dispatch=Int, name=:my_int_fun)
+eval(code)
+```
+
+Let's check the methods of `my_int_fun` and `my_int_fun!`:
+
+```@example ff2
+methods(my_int_fun)
+```
+```@example ff2
+methods(my_int_fun!)
+```
+
+Notice that because we set the `dispatch` argument to `Int`, all methods of
+either the mutating or allocating function require that an `Int` is passed to
+direct dispatch.
+
+Let's try calling our function
+
+```julia
+V = [π, 5.0, 0.8]
+p = [0.98]
+my_int_fun(V, p)  # doesn't work
+```
+
+The above fails with
+
+```
+ERROR: MethodError: no method matching my_int_fun(::Array{Float64,1}, ::Array{Float64,1})
+```
+
+Now if we call that method where the first argument is an *instance* of `Int`,
+it will work
+
+```@example ff2
+V = [π, 5.0, 0.8]  # hide
+p = [0.98]  # hide
+my_int_fun(1, V, p)
+```
+
+The actual integer we pass doesn't matter
+
+```@example ff2
+my_int_fun(10_000_001, V, p)
+```
+
+We can still evaluate derivatives
+
+```@example ff2
+my_int_fun(Der{1}, 1, V, p)
+```
+
+Notice that the order of derivative comes first, then the dispatch argument,
+then all other function arguments.
+
+Higher order derivatives also work
+
+```@example ff2
+my_int_fun(Der{2}, 10, V, p)
+```
+
+```@example ff2
+my_int_fun(Der{5}, 10, V, p)
+```
+
+```@example ff2
+my_int_fun(Der{10}, 10, V, p)
+```
+
+## With grouped `args`
+
+Finally we show one more example of how to use an associative mapping for the
+`FunctionFactory` `args` field to produce a function with grouped arguments.
+
+```@example ff3
+using Dolang  # hide
+eqs = [
+    :(sin(x(0)) + exp(2*x(1))),
+    :(y(0) / (2 * (1 - β))),
+]
+args = Dict(
+    :a => [(:x, 0), (:y, 0)],
+    :b => [(:x, 1)]
+)
+params = [:β]
+ff = FunctionFactory(eqs, args, params, funname=:grouped_args)
+code = make_function(ff)
+eval(code)
+```
+
+Let's take a look at the methods for this function
+
+```@example ff3
+methods(grouped_args)
+```
+
+Notice that each of theses routines have arguments for `a`, `b`, and `p`
+instead of just the `V` and `p` we saw in previous examples.
+
+When we evaluate these methods we need to be sure that `a` has two elements,
+`b` has one, and `p` has one:
+
+```@example ff3
+a = [π, 5.0]
+b = [0.8]
+p = [0.98]
+grouped_args(a, b, p)
+```
+
+Notice we can evaluate a method where `a` and `b` are vectorized. Here `p` will
+be repeated as necessary
+
+```@example ff3
+grouped_args([a a+1]', [b b+1]', p)
+```
+
+We can also evaluate a partially vectorized version of the function where only
+`a` is a matrix and `b` is a vector. In this case both `b` and `p` will be
+repeated
+
+```@example ff3
+grouped_args([a a+1]', b, p)
+```
+
+Non-allocating versions of the function are also available
+
+```@example ff3
+out = zeros(2)
+grouped_args!(out, a, b, p)
+@show @allocated grouped_args!(out, a, b, p)
+@show out
+```
+
+As of today (2017-06-13) derivative code does not work for functions with
+grouped args. Trying to evaluate a derivative will result in an error that
+looks like this:
+
+```
+julia> grouped_args(Der{1}, a, b, p)
+ERROR: MethodError: no method matching equation_block(::Dolang.FunctionFactory{Dict{Symbol,Array{Tuple{Symbol,Int64},1}},Array{Symbol,1},Dict{Symbol,Any},DataType}, ::Type{Dolang.Der{1}})
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,14 @@
+# Dolang.jl
+
+```@meta
+CurrentModule = Dolang
+```
+
+Dolang is an implementation of the dolo language and provides utilities for
+symbolic manipulation and efficient compilation of symbols and expressions into
+performant Julia functions.
+
+To read more about the available routines, read the [Symbolic
+manipulation](@ref) and [Dolang's compiler](@ref) chapters. To get started
+right away with using the Dolang compiler skip directly to the
+[Examples](@ref).

--- a/docs/src/symbolic.md
+++ b/docs/src/symbolic.md
@@ -1,0 +1,534 @@
+# Symbolic manipulation
+
+```@meta
+DocTestSetup = quote
+    using Dolang
+end
+```
+
+One of Dolang's key features is providing an _extensible_ and _consistent_ set
+of routines for doing operations on symbolic objects. We'll discuss each of
+these routines in turn
+
+```@contents
+Pages = ["symbolic.md"]
+Depth = 2
+```
+
+## `normalize`
+
+The `normalize` function converts expressions and symbols into Dolang's internal
+representation. There are various methods for this function:
+
+```@docs
+normalize(::Symbol)
+```
+
+**Examples**
+
+```jldoctest
+julia> normalize(:c)
+:_c_
+
+julia> normalize(:_c)
+:__c_
+
+julia> normalize(:_c_)
+:_c_
+
+julia> normalize(:x_ijk)
+:_x_ijk_
+
+julia> normalize(:x_ijk_)
+:_x_ijk__
+
+julia> normalize(:_x_ijk_)
+:_x_ijk_
+```
+
+```@docs
+normalize(::Number)
+```
+
+**Examples**
+
+```jldoctest
+julia> normalize(-1)
+-1
+
+julia> normalize(0)
+0
+
+julia> normalize(1)
+1
+```in
+
+```@docs
+normalize(::Symbol, ::Integer)
+```
+
+**Examples**
+
+```jldoctest
+julia> normalize(:x, 0)
+:_x__0_
+
+julia> normalize(:x, 1)
+:_x__1_
+
+julia> normalize(:x, -1)
+:_x_m1_
+
+julia> normalize(:x, -100)
+:_x_m100_
+
+julia> normalize("x", 0)
+:_x__0_
+
+julia> normalize("x", 1)
+:_x__1_
+
+julia> normalize("x", -1)
+:_x_m1_
+
+julia> normalize("x", -100)
+:_x_m100_
+```
+
+```@docs
+normalize(::Tuple{Symbol,Integer})
+```
+
+**Examples**
+
+```jldoctest
+julia> normalize((:x, 0))
+:_x__0_
+
+julia> normalize((:x, 1))
+:_x__1_
+
+julia> normalize((:x, -1))
+:_x_m1_
+
+julia> normalize((:x, -100))
+:_x_m100_
+```
+
+```@docs
+normalize(::Expr)
+```
+
+**Examples**
+
+```jldoctest
+julia> normalize(:(a(1) - b - c(2) + d(-1)))
+:(((_a__1_ - _b_) - _c__2_) + _d_m1_)
+
+julia> normalize(:(sin(x)))
+:(sin(_x_))
+
+julia> normalize(:(sin(x(0))))
+:(sin(_x__0_))
+
+julia> normalize(:(dot(x, y(1))))
+:(dot(_x_, _y__1_))
+
+julia> normalize(:(beta * c(0)/c(1) * (alpha*y(1)/k(1) * (1-mu(1)) + 1 - delta_k) - 1))
+:(((_beta_ * _c__0_) / _c__1_) * ((((_alpha_ * _y__1_) / _k__1_) * (1 - _mu__1_) + 1) - _delta_k_) - 1)
+
+julia> normalize(:(x = log(y(-1))); targets=[:x])  # with targets
+:(_x_ = log(_y_m1_))
+
+julia> normalize(:(x = log(y(-1))))  # without targets
+:(log(_y_m1_) - _x_)
+```
+
+```@docs
+normalize(::String)
+```
+
+**Examples**: see above for more
+
+```jldoctest
+julia> normalize("x = log(y(-1))"; targets=[:x])  # with targets
+:(_x_ = log(_y_m1_))
+
+julia> normalize("x = log(y(-1))")  # without targets
+:(log(_y_m1_) - _x_)
+```
+
+```@docs
+normalize(::Vector{Expr})
+```
+
+**Examples**:
+
+```jldoctest
+julia> normalize([:(sin(x(0))), :(dot(x, y(1))), :(x = log(y(-1)))])
+quote
+    sin(_x__0_)
+    dot(_x_, _y__1_)
+    log(_y_m1_) - _x_
+end
+
+julia> normalize([:(sin(x(0))), :(dot(x, y(1))), :(x = log(y(-1)))], targets=[:x])
+quote
+    sin(_x__0_)
+    dot(_x_, _y__1_)
+    _x_ = log(_y_m1_)
+end
+```
+
+## `time_shift`
+
+`time_shift` shifts an expression by a specified number of time periods. As
+with normalize, there are many methods for this function, which will will
+describe one at a time.
+
+```@docs
+time_shift(::Expr, ::Integer, ::Set{Symbol}, ::Associative)
+time_shift(::Expr, ::Integer)
+```
+
+**Examples**
+
+```jldoctest
+julia> defs = Dict(:a=>:(b(-1)/c));
+
+julia> defs2 = Dict(:a=>:(b(-1)/c(0)));
+
+julia> funcs = [:foobar];
+
+julia> shift = 1;
+
+julia> time_shift(:(a+b(1) + c), shift)
+:(a + b(2) + c)
+
+julia> time_shift(:(a+b(1) + c(0)), shift)
+:(a + b(2) + c(1))
+
+julia> time_shift(:(a+b(1) + c), shift, defs=defs)
+:(b(0) / c + b(2) + c)
+
+julia> time_shift(:(a+b(1) + c(0)), shift, defs=defs)
+:(b(0) / c + b(2) + c(1))
+
+julia> time_shift(:(a+b(1) + c(0)), shift, defs=defs2)
+:(b(0) / c(1) + b(2) + c(1))
+
+julia> time_shift(:(a+b(1) + foobar(c)), shift, functions=funcs)
+:(a + b(2) + foobar(c))
+
+julia> time_shift(:(a+b(1) + foobar(c)), shift, defs=defs, functions=funcs)
+:(b(0) / c + b(2) + foobar(c))
+
+julia> shift = -1;
+
+julia> time_shift(:(a+b(1) + c), shift)
+:(a + b(0) + c)
+
+julia> time_shift(:(a+b(1) + c(0)), shift)
+:(a + b(0) + c(-1))
+
+julia> time_shift(:(a+b(1) + c), shift, defs=defs)
+:(b(-2) / c + b(0) + c)
+
+julia> time_shift(:(a+b(1) + c(0)), shift, defs=defs)
+:(b(-2) / c + b(0) + c(-1))
+
+julia> time_shift(:(a+b(1) + c(0)), shift, defs=defs2)
+:(b(-2) / c(-1) + b(0) + c(-1))
+
+julia> time_shift(:(a+b(1) + foobar(c)), shift, functions=funcs)
+:(a + b(0) + foobar(c))
+
+julia> time_shift(:(a+b(1) + foobar(c)), shift, defs=defs, functions=funcs)
+:(b(-2) / c + b(0) + foobar(c))
+```
+
+```@docs
+time_shift(::Symbol, ::Integer, ::Set{Symbol}, ::Associative)
+```
+
+**Examples**
+
+```jldoctest
+julia> defs = Dict(:a=>:(b(-1)/c));
+
+julia> defs2 = Dict(:a=>:(b(-1)/c(0)));
+
+julia> shift = 1;
+
+julia> funcs = Set([:foobar]);
+
+julia> time_shift(:a, shift, funcs, Dict())
+:a
+
+julia> time_shift(:a, shift, funcs, defs)
+:(b(0) / c)
+
+julia> time_shift(:a, shift, funcs, defs2)
+:(b(0) / c(1))
+
+julia> time_shift(:b, shift, funcs, defs)
+:b
+
+julia> shift = -1;
+
+julia> time_shift(:a, shift, funcs, Dict())
+:a
+
+julia> time_shift(:a, shift, funcs, defs)
+:(b(-2) / c)
+
+julia> time_shift(:a, shift, funcs, defs2)
+:(b(-2) / c(-1))
+
+julia> time_shift(:b, shift, funcs, defs)
+:b
+```
+
+```@docs
+time_shift(::Number)
+```
+
+**Examples**
+
+```jldoctest
+julia> time_shift(1)
+1
+
+julia> time_shift(2)
+2
+
+julia> time_shift(-1)
+-1
+
+julia> time_shift(-2)
+-2
+```
+
+## `steady_state`
+
+The `steady_state` function will set the period for all "timed" variables to 0.
+
+```@docs
+steady_state(::Symbol, ::Set{Symbol}, ::Associative)
+```
+
+```jldoctest
+julia> defs = Dict(:a=>:(b(-1)/c + d), :d=>:(exp(b(0))));
+
+julia> steady_state(:c, Set{Symbol}(), defs)
+:c
+
+julia> steady_state(:d, Set{Symbol}(), defs)
+:(exp(b))
+
+julia> steady_state(:a, Set{Symbol}(), defs)  # recursive def resolution
+:(b / c + exp(b))
+
+julia> steady_state(1, Set{Symbol}(), defs)
+1
+
+julia> steady_state(-1, Set{Symbol}(), defs)
+-1
+```
+
+**Examples**
+
+
+```@docs
+steady_state(::Expr, ::Set{Symbol}, ::Associative)
+steady_state(::Expr)
+```
+
+**Examples**
+
+```jldoctest
+julia> steady_state(:(a+b(1) + c))
+:(a + b + c)
+
+julia> steady_state(:(a+b(1) + c))
+:(a + b + c)
+
+julia> steady_state(:(a+b(1) + c), defs=Dict(:a=>:(b(-1)/c)))
+:(b / c + b + c)
+
+julia> steady_state(:(a+b(1)+c+foobar(c)))
+ERROR: Dolang.UnknownFunctionError(:foobar, "Unknown function foobar")
+
+julia> steady_state(:(a+b(1) + foobar(c)), functions=[:foobar])
+:(a + b + foobar(c))
+```
+
+## `list_symbols`
+
+`list_symbols` will walk an expression and determine which symbols are used as
+potentially time varying *variables* and which symbols are used as static
+*parameters*.
+
+```@docs
+list_symbols!(out, ::Expr, ::Set{Symbol})
+list_symbols(::Expr)
+```
+
+**Examples**
+
+```jldoctest
+julia> list_symbols(:(a + b(1) + c))
+Dict{Symbol,Any} with 2 entries:
+  :variables  => Set(Tuple{Symbol,Int64}[(:b, 1)])
+  :parameters => Set(Symbol[:a, :c])
+
+julia> list_symbols(:(a + b(1) + c + b(0)))
+Dict{Symbol,Any} with 2 entries:
+  :variables  => Set(Tuple{Symbol,Int64}[(:b, 1), (:b, 0)])
+  :parameters => Set(Symbol[:a, :c])
+
+julia> list_symbols(:(a + b(1) + c + b(0) + foobar(x)))
+ERROR: Dolang.UnknownFunctionError(:foobar, "Unknown function foobar")
+
+julia> list_symbols(:(a + b(1) + c + b(0) + foobar(x)), functions=Set([:foobar]))
+Dict{Symbol,Any} with 2 entries:
+  :variables  => Set(Tuple{Symbol,Int64}[(:b, 1), (:b, 0)])
+  :parameters => Set(Symbol[:a, :c, :x])
+```
+
+## `list_variables`
+
+`list_variables` will return the `:variables` key that results from calling
+`list_symbols`. The type of the returned object will be a `Set` of
+`Tuple{Symbol,Int}`, where each item describes the symbol that appeared and the
+corresponding date.
+
+```@docs
+list_variables(:Any)
+```
+
+**Examples**
+
+```jldoctest
+julia> list_variables(:(a + b(1) + c))
+Set(Tuple{Symbol,Int64}[(:b, 1)])
+
+julia> list_variables(:(a + b(1) + c + b(0)))
+Set(Tuple{Symbol,Int64}[(:b, 1), (:b, 0)])
+
+julia> list_variables(:(a + b(1) + c + b(0) + foobar(x)))
+ERROR: Dolang.UnknownFunctionError(:foobar, "Unknown function foobar")
+
+julia> list_variables(:(a + b(1) + c + b(0) + foobar(x)), functions=Set([:foobar]))
+Set(Tuple{Symbol,Int64}[(:b, 1), (:b, 0)])
+```
+
+## `list_parameters`
+
+`list_parameters` will return the `:parameters` key that results from calling
+`list_symbols`. The returned object will be `Set{Symbol}` where each item
+represents the symbol that appeared without a date.
+
+```@docs
+list_parameters(::Any)
+```
+
+**Examples**
+
+```jldoctest
+julia> list_variables(:(a + b(1) + c + b(0) + foobar(x)), functions=Set([:foobar]))
+Set(Tuple{Symbol,Int64}[(:b, 1), (:b, 0)])
+
+julia> list_parameters(:(a + b(1) + c))
+Set(Symbol[:a, :c])
+
+julia> list_parameters(:(a + b(1) + c + b(0)))
+Set(Symbol[:a, :c])
+
+julia> list_parameters(:(a + b(1) + c + b(0) + foobar(x)))
+ERROR: Dolang.UnknownFunctionError(:foobar, "Unknown function foobar")
+
+julia> list_parameters(:(a + b(1) + c + b(0) + foobar(x)), functions=Set([:foobar]))
+Set(Symbol[:a, :c, :x])
+```
+
+## `subs`
+
+`subs` will replace a symbol or expression with a different value, where the
+value has type `Union{Symbol,Expr,Number}`
+
+The first method of this function is very specific, and matches only a
+particular pattern:
+
+```@docs
+subs(::Union{Expr,Symbol,Number}, from, ::Union{Symbol,Expr,Number}, ::Set{Symbol})
+```
+
+**Examples**
+
+```jldoctest
+julia> subs(:(a + b(1) + c), :a, :(b(-1)/c + d), Set{Symbol}())
+:((b(-1) / c + d) + b(1) + c)
+
+julia> subs(:(a + b(1) + c), :d, :(b(-1)/c + d), Set{Symbol}())
+:(a + b(1) + c)
+```
+
+```@docs
+subs(::Expr, ::Associative, ::Set{Symbol})
+subs(::Expr, ::Associative)
+```
+
+**Examples**
+
+```jldoctest
+julia> ex = :(a + b);
+
+julia> d = Dict(:b => :(c/a), :c => :(2a));
+
+julia> subs(ex, d)  # subs is not recursive -- c is not replaced
+:(a + c / a)
+```
+
+## `csubs`
+
+`csubs` is closely related to `subs`, but is more Clever and applies
+substitutions recursively.
+
+```@docs
+csubs(::Expr, ::Associative, ::Set{Symbol})
+csubs(::Expr, ::Associative)
+```
+
+**Examples**
+
+```jldoctest
+julia> ex = :(a + b);
+
+julia> d = Dict(:b => :(c/a), :c => :(2a));
+
+julia> csubs(ex, d)  # csubs is recursive -- c is replaced
+:(a + (2a) / a)
+
+julia> d1 = Dict(:monty=> :python, :run=>:faster, :eat=>:more);
+
+julia> csubs(:(monty(run + eat, eat)), d1)
+:(python(faster + more, more))
+
+julia> csubs(:(a + b(0) + b(1)), Dict(:b => :(c(0) + d(1))))
+:(a + (c(0) + d(1)) + (c(1) + d(2)))
+
+julia> csubs(:(a + b(0) + b(1)), Dict((:b, 1) => :(c(0) + d(1))))
+:(a + b(0) + (c(0) + d(1)))
+
+julia> csubs(:(a + b(0) + b(1)), Dict(:b => :(c + d(1))))
+:(a + (c + d(1)) + (c + d(2)))
+
+julia> csubs(:(a + b(0) + b(1)), Dict((:b, 1) => :(c + d(1))))
+:(a + b(0) + (c + d(1)))
+
+julia> d = Dict((:b, 0) => :(c + d(1)), (:b, 1) => :(c(100) + d(2)));
+
+julia> csubs(:(a + b + b(1)), d)
+:(a + (c + d(1)) + (c(100) + d(2)))
+```

--- a/src/Dolang.jl
+++ b/src/Dolang.jl
@@ -34,7 +34,7 @@ using Compat: view, String, @compat
 
 import Base: ==, normalize
 
-export make_method, Der, FunctionFactory, normalize, is_time_shift, time_shift,
+export make_function, Der, FunctionFactory, normalize, is_time_shift, time_shift,
        subs, csubs
 
 # come convenience methods

--- a/src/Dolang.jl
+++ b/src/Dolang.jl
@@ -35,7 +35,8 @@ using Compat: view, String, @compat
 import Base: ==, normalize
 
 export make_function, Der, FunctionFactory, normalize, is_time_shift, time_shift,
-       subs, csubs
+       subs, csubs, steady_state, list_symbols, list_symbols!, list_variables,
+       list_parameters
 
 # come convenience methods
 _replace_star_star(s::AbstractString) = replace(s, "**", "^")

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -269,8 +269,8 @@ function make_deriv_loop(i::Int, der_order::Int)
     # build _inner_part of the loop body. This will include the actual derivation
     # if i == der_order or it will differentiate the current expression wrt
     # the ith variable and recursively call this function with i = i+1
+    sym_to_diff = i == 1 ? :eq_prepped : Symbol("diff_v_", i-1)
     if i == der_order
-        sym_to_diff = i == 1 ? :eq_prepped : Symbol("diff_v_", i-1)
         index_tuple = Expr(:tuple, [Symbol("iv_", j) for j in 1:i]...)
         inner_loop_guts = quote
             $diff_sym = deriv($sym_to_diff, normalize(ff.args[$i_sym]))
@@ -283,7 +283,7 @@ function make_deriv_loop(i::Int, der_order::Int)
     else
         inner_loop_guts = Expr(
             :block,
-            :($diff_sym = deriv(eq_prepped, normalize(ff.args[$i_sym]))),
+            :($diff_sym = deriv($sym_to_diff, normalize(ff.args[$i_sym]))),
             make_deriv_loop(i+1, der_order)
         )
     end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -615,9 +615,7 @@ function make_function(
         eqs::Vector{Expr}, variables::AbstractVector,
         to_diff::AbstractVector=1:length(variables);
         dispatch::DataType=SkipArg,
-        targets=Symbol[],
-        orders::AbstractVector{Int}=[0, 1],
-        name::Symbol=:anon, allocating::Bool=true
+        targets=Symbol[], name::Symbol=:anon
     )
 
     args = variables[to_diff]
@@ -628,7 +626,7 @@ function make_function(
         dispatch, eqs, args, params; targets=targets, funname=name
     )
 
-    make_method(ff; allocating=allocating, orders=orders)
+    make_function(ff)
 
 end
 
@@ -640,7 +638,7 @@ function super_signature(ff::FunctionFactory, sig_func)
     sig
 end
 
-function make_super_function(ff::FunctionFactory)
+function make_function(ff::FunctionFactory)
     # make generated, allocating function
     sig = super_signature(ff, signature)
     body = Expr(:block, :(ff = $ff), :(func_body(ff, Der{D})))
@@ -665,6 +663,10 @@ function make_super_function(ff::FunctionFactory)
         no_der_func = Expr(:function, no_der_sig, call_der0_sig)
         push!(out.args, no_der_func)
     end
+
+    # also make vectorized functions for Der{0}
+    push!(out.args, build_vec_function(ff, Der{0}))
+    push!(out.args, build_vec_function!(ff, Der{0}))
 
     out
 end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -640,5 +640,16 @@ function make_function(ff::FunctionFactory)
     push!(out.args, build_vec_function(ff, Der{0}))
     push!(out.args, build_vec_function!(ff, Der{0}))
 
+
+    if !HAVE_SYMENGINE
+        # for Calculus.jl the @generated functions do not work -- we need to
+        # construct code for levels 0, 1, and 2 here instead of at call time
+        push!(out.args, build_function(ff, Der{0}))  # allocating levels
+        push!(out.args, build_function(ff, Der{1}))  # allocating jacobian
+        push!(out.args, build_function(ff, Der{2}))  # allocating hessian
+        push!(out.args, build_function!(ff, Der{0}))  # mutating levels
+        push!(out.args, build_function!(ff, Der{1}))  # mutating jacobian
+    end
+
     out
 end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -121,29 +121,32 @@ _extra_args{n}(ff::FunctionFactory, d::TDer{n}) =
                                 [:(::Dolang.TDer{$n}),
                                  :($(DISPATCH_ARG)::$(ff.dispatch))]
 
-function signature{n,T1<:FlatArgs}(ff::FunctionFactory{T1}, d::TDer{n}=Der{0})
+function signature{n,T1<:FlatArgs}(ff::FunctionFactory{T1}, d::TDer{n}=Der{0},
+                                   argtype::Symbol=:AbstractVector)
     Expr(
         :call,
         ff.funname,
         _extra_args(ff, d)...,
-        :(V::AbstractVector),
+        Expr(:(::), :V, argtype),
         param_names(ff)...
     )
 end
 
-function signature{n,T1<:GroupedArgs}(ff::FunctionFactory{T1}, d::TDer{n}=Der{0})
+function signature{n,T1<:GroupedArgs}(ff::FunctionFactory{T1}, d::TDer{n}=Der{0},
+                                      argtype::Symbol=:AbstractVector)
     Expr(
         :call,
         ff.funname,
         _extra_args(ff, d)...,
-        [:($(k)::AbstractVector) for k in keys(ff.args)]...,
+        [Expr(:(::), k, argtype) for k in keys(ff.args)]...,
         param_names(ff)...
     )
 end
 
 "Method signature for mutating version of the function"
-function signature!{n}(ff::FunctionFactory, d::TDer{n}=Der{0})
-    sig = signature(ff, d)
+function signature!{n}(ff::FunctionFactory, d::TDer{n}=Der{0},
+                       argtype::Symbol=:AbstractVector)
+    sig = signature(ff, d, argtype)
 
     # convert name to `!` version and insert `out` as first argument
     sig.args[1] = Symbol(sig.args[1], "!")

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -309,7 +309,7 @@ end
 # code to generate derivative expressions. This could be put in the body of
 # the `@generated` function, but that makes it hard for me to see the code
 # that is generated, so I make it a standalone function.
-@compat function derivative_exprs_impl{T<:FlatArgs,D}(::Type{<:FunctionFactory{T}}, ::TDer{D})
+@compat function derivative_exprs_impl{D}(::Type{<:FunctionFactory{<:FlatArgs}}, ::TDer{D})
     # first, build the body of loops that differentiate an equation.
     body = make_deriv_loop(1, D)
 

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -640,7 +640,20 @@ end
 # arg_name #
 # ---------#
 
-arg_name(s::Symbol) = s
+function arg_name(s::Symbol)::Symbol
+    # is the symbol already normalized?
+    str_s = string(s)
+    if str_s[1] == str_s[end] == '_'
+        parts = match(r"^_(.+)_[m_]\d+_$", str_s)
+        if parts === nothing
+            return s
+        else
+            return Symbol(parts[1])
+        end
+    else
+        return s
+    end
+end
 arg_name(s::Tuple{Symbol,Int}) = s[1]
 function arg_name(ex::Expr)::Symbol
     if is_time_shift(ex)
@@ -654,7 +667,24 @@ function arg_name(ex::Expr)::Symbol
     end
 end
 
-arg_time(s::Symbol) = 0
+function arg_time(s::Symbol)::Int
+    # is the symbol already normalized?
+    str_s = string(s)
+    if str_s[1] == str_s[end] == '_'
+        # yep, we are already normalized, need to extract the
+        r = r"(m)?(\d+)_$"
+        parts = match(r, str_s)
+        if parts === nothing
+            # not a match
+            return 0
+        else
+            shift = parse(Int, parts[2])
+            return parts[1] === nothing ? shift : -shift
+        end
+    else
+        return 0
+    end
+end
 arg_time(s::Tuple{Symbol,Int}) = s[2]
 function arg_time(ex::Expr)::Int
     if is_time_shift(ex)

--- a/src/util.jl
+++ b/src/util.jl
@@ -6,8 +6,11 @@
 # extract a single element. If `x` is a Matrix then extract one column of the
 # matrix
 @inline _unpack_var(x::AbstractVector, i::Integer) = x[i]
-
 @inline _unpack_var(x::AbstractMatrix, i::Integer) = view(x, :, i)
+
+# inlined function to extract a single observations of a vector fo variables.
+@inline _unpack_obs(x::AbstractMatrix, i::Integer) = view(x, i, :)
+@inline _unpack_obs(x::AbstractVector, i::Integer) = x
 
 # similar to _unpack_var, but instead assigns one element of a vector or one
 # column of a matrix

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -563,19 +563,21 @@ end
             @test want ≈ @inferred fun(Der{2}, V, p)
 
             # and third derivative code
-            want = [Dict{NTuple{3,Int},Float64}(), Dict{NTuple{3,Int},Float64}()]
-            want[1][(1, 1, 1)] = -6 * b * (1-c) / (am^4) # ∂³foo/∂am³
-            want[1][(1, 1, 3)] = 2 * (1-c) / (am^3)      # ∂³foo/∂am²b
-            want[1][(1, 1, 4)] = -2 * b / (am^3)         # ∂³foo/∂am²c
-            want[1][(2, 2, 2)] = 2/(a^3)                 # ∂³foo/∂a³
-            want[1][(1, 3, 4)] = 1/(am^2)                # ∂³foo / ∂a ∂b ∂c
+            if DOLANG.HAVE_SYMENGINE
+                want = [Dict{NTuple{3,Int},Float64}(), Dict{NTuple{3,Int},Float64}()]
+                want[1][(1, 1, 1)] = -6 * b * (1-c) / (am^4) # ∂³foo/∂am³
+                want[1][(1, 1, 3)] = 2 * (1-c) / (am^3)      # ∂³foo/∂am²b
+                want[1][(1, 1, 4)] = -2 * b / (am^3)         # ∂³foo/∂am²c
+                want[1][(2, 2, 2)] = 2/(a^3)                 # ∂³foo/∂a³
+                want[1][(1, 3, 4)] = 1/(am^2)                # ∂³foo / ∂a ∂b ∂c
 
-            have = @inferred fun(Der{3}, V, p)
+                have = @inferred fun(Der{3}, V, p)
 
-            @test length(have[1]) == 5
-            @test length(have[2]) == 0
-            for (k, v) in have[1]
-                @test v ≈ want[1][k]
+                @test length(have[1]) == 5
+                @test length(have[2]) == 0
+                for (k, v) in have[1]
+                    @test v ≈ want[1][k]
+                end
             end
         end
     end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -563,7 +563,7 @@ end
     end
 
     @testset " evaluating compiled code" begin
-        eval(current_module(), Dolang.make_method(ff, orders=[0,1]))
+        eval(current_module(), Dolang.make_method(ff, orders=[0,1,2]))
         u = rand()
         V = rand(6)+4
         am, a, b, c, cp, dp = V
@@ -612,6 +612,20 @@ end
         out2 = similar(want)
         myfun!(Der{1}, out2, V, p)
         @test want ≈ out2
+
+        # and second derivative code
+        want = zeros(Float64, 2, 6*6)
+        want[1, 1] = 2 * b * (1-c) / (am^3)  # ∂²foo/∂am²
+        want[1, 3] = -1 *(1-c)/ (am*am)  # ∂²foo/∂am ∂b
+        want[1, 4] = b /(am^2)  # ∂²foo/∂am ∂c
+        want[1, 8] = -1/(a^2)  # ∂²foo/∂a²
+        want[1, 13] = -(1-c)/(am^2)  # ∂²foo/∂c ∂am
+        want[1, 16] = -1/am  # ∂²foo/∂c²
+        want[1, 19] = b/(am^2)  # ∂²foo/∂b ∂am
+        want[1, 21] = -1/am  # ∂²foo/∂b²
+
+        @test want ≈ @inferred myfun(Der{2}, V, p)
+
 
     end
 end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -563,7 +563,7 @@ end
             @test want ≈ @inferred fun(Der{2}, V, p)
 
             # and third derivative code
-            if DOLANG.HAVE_SYMENGINE
+            if Dolang.HAVE_SYMENGINE
                 want = [Dict{NTuple{3,Int},Float64}(), Dict{NTuple{3,Int},Float64}()]
                 want[1][(1, 1, 1)] = -6 * b * (1-c) / (am^4) # ∂³foo/∂am³
                 want[1][(1, 1, 3)] = 2 * (1-c) / (am^3)      # ∂³foo/∂am²b

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -12,7 +12,6 @@ const grouped_args = OrderedDict(:x=>[(:a, -1),], :y=>[(:a, 0), (:b, 0), (:c, 0)
 const flat_params = [:beta, :delta]
 const grouped_params = Dict(:p => [:u])
 
-
 args2 = vcat(args, targets)::Vector{Tuple{Symbol,Int}}
 
 ff = Dolang.FunctionFactory(eqs, args, params, targets=targets, defs=defs,
@@ -176,21 +175,29 @@ end
     end))
 
     want_vec = Dolang._filter_lines!(:(begin
-        function myfun(::Dolang.TDer{0},V::AbstractMatrix,p)
+        function myfun(::Dolang.TDer{0},V::AbstractArray,p)
             out = Dolang._allocate_out(eltype(V),2,V)
-            nrow = size(V,1)
-            for _row = 1:nrow
-                @inbounds out[_row,:] = myfun($(Dolang.Der{0}),view(V,_row,:),p)
+            begin
+                nrow = size(out,1)
+                for _row = 1:nrow
+                    __out__row = view(out, _row, :)
+                    __V__row = Dolang._unpack_obs(V, _row)
+                    myfun!($(Dolang.Der{0}),__out__row, __V__row, p)
+                end
+                return out
             end
-            return out
         end
-        function myfun(V::AbstractMatrix,p)
+        function myfun(V::AbstractArray,p)
             out = Dolang._allocate_out(eltype(V),2,V)
-            nrow = size(V,1)
-            for _row = 1:nrow
-                @inbounds out[_row,:] = myfun($(Dolang.Der{0}),view(V,_row,:),p)
+            begin
+                nrow = size(out,1)
+                for _row = 1:nrow
+                    __out__row = view(out, _row, :)
+                    __V__row = Dolang._unpack_obs(V, _row)
+                    myfun!($(Dolang.Der{0}),__out__row, __V__row, p)
+                end
+                return out
             end
-            return out
         end
     end
     ))
@@ -257,7 +264,7 @@ end
     end))
 
     want!_vec = Dolang._filter_lines!(:(begin
-        function myfun!(::Dolang.TDer{0},out,V::AbstractMatrix,p)
+        function myfun!(::Dolang.TDer{0},out,V::AbstractArray,p)
             begin
                 expected_size = Dolang._output_size(2,V)
                 if size(out) != expected_size
@@ -265,13 +272,17 @@ end
                     throw(DimensionMismatch(msg))
                 end
             end
-            nrow = size(V,1)
-            for _row = 1:nrow
-                @inbounds out[_row,:] = myfun($(Dolang.Der{0}),view(V,_row,:),p)
+            begin
+                nrow = size(out,1)
+                for _row = 1:nrow
+                    __out__row = view(out, _row, :)
+                    __V__row = Dolang._unpack_obs(V, _row)
+                    myfun!($(Dolang.Der{0}),__out__row, __V__row, p)
+                end
+                return out
             end
-            return out
         end
-        function myfun!(out,V::AbstractMatrix,p)
+        function myfun!(out,V::AbstractArray,p)
             begin
                 expected_size = Dolang._output_size(2,V)
                 if size(out) != expected_size
@@ -279,11 +290,15 @@ end
                     throw(DimensionMismatch(msg))
                 end
             end
-            nrow = size(V,1)
-            for _row = 1:nrow
-                @inbounds out[_row,:] = myfun($(Dolang.Der{0}),view(V,_row,:),p)
+            begin
+                nrow = size(out,1)
+                for _row = 1:nrow
+                    __out__row = view(out, _row, :)
+                    __V__row = Dolang._unpack_obs(V, _row)
+                    myfun!($(Dolang.Der{0}),__out__row, __V__row, p)
+                end
+                return out
             end
-            return out
         end
     end
     ))
@@ -338,21 +353,29 @@ end
     end))
 
     want_d_vec = Dolang._filter_lines(:(begin
-        function myfun(::Dolang.TDer{0},$(Dolang.DISPATCH_ARG)::$(Int),V::AbstractMatrix,p)
+        function myfun(::Dolang.TDer{0},$(Dolang.DISPATCH_ARG)::$(Int),V::AbstractArray,p)
             out = Dolang._allocate_out(eltype(V),2,V)
-            nrow = size(V,1)
-            for _row = 1:nrow
-                @inbounds out[_row,:] = myfun($(Dolang.Der{0}),$(Dolang.DISPATCH_ARG)::$(Int),view(V,_row,:),p)
+            begin
+                nrow = size(out, 1)
+                for _row = 1:nrow
+                    __out__row = view(out, _row, :)
+                    __V__row = Dolang._unpack_obs(V, _row)
+                    myfun!($(Dolang.Der{0}),$(Dolang.DISPATCH_ARG)::$(Int), __out__row, __V__row, p)
+                end
+                return out
             end
-            return out
         end
-        function myfun($(Dolang.DISPATCH_ARG)::$(Int),V::AbstractMatrix,p)
+        function myfun($(Dolang.DISPATCH_ARG)::$(Int),V::AbstractArray,p)
             out = Dolang._allocate_out(eltype(V),2,V)
-            nrow = size(V,1)
-            for _row = 1:nrow
-                @inbounds out[_row,:] = myfun($(Dolang.Der{0}),$(Dolang.DISPATCH_ARG)::$(Int),view(V,_row,:),p)
+            begin
+                nrow = size(out, 1)
+                for _row = 1:nrow
+                    __out__row = view(out, _row, :)
+                    __V__row = Dolang._unpack_obs(V, _row)
+                    myfun!($(Dolang.Der{0}),$(Dolang.DISPATCH_ARG)::$(Int), __out__row, __V__row, p)
+                end
+                return out
             end
-            return out
         end
     end))
 
@@ -418,7 +441,7 @@ end
     end))
 
     want_d!_vec = Dolang._filter_lines(:(begin
-        function myfun!(::Dolang.TDer{0},$(Dolang.DISPATCH_ARG)::$(Int),out,V::AbstractMatrix,p)
+        function myfun!(::Dolang.TDer{0},$(Dolang.DISPATCH_ARG)::$(Int),out,V::AbstractArray,p)
             begin
                 expected_size = Dolang._output_size(2,V)
                 if size(out) != expected_size
@@ -426,13 +449,17 @@ end
                     throw(DimensionMismatch(msg))
                 end
             end
-            nrow = size(V,1)
-            for _row = 1:nrow
-                @inbounds out[_row,:] = myfun($(Dolang.Der{0}),$(Dolang.DISPATCH_ARG)::$(Int),view(V,_row,:),p)
+            begin
+                nrow = size(out, 1)
+                for _row = 1:nrow
+                    __out__row = view(out, _row, :)
+                    __V__row = Dolang._unpack_obs(V, _row)
+                    myfun!($(Dolang.Der{0}),$(Dolang.DISPATCH_ARG)::$(Int), __out__row, __V__row, p)
+                end
+                return out
             end
-            return out
         end
-        function myfun!($(Dolang.DISPATCH_ARG)::$(Int),out,V::AbstractMatrix,p)
+        function myfun!($(Dolang.DISPATCH_ARG)::$(Int),out,V::AbstractArray,p)
             begin
                 expected_size = Dolang._output_size(2,V)
                 if size(out) != expected_size
@@ -440,11 +467,15 @@ end
                     throw(DimensionMismatch(msg))
                 end
             end
-            nrow = size(V,1)
-            for _row = 1:nrow
-                @inbounds out[_row,:] = myfun($(Dolang.Der{0}),$(Dolang.DISPATCH_ARG)::$(Int),view(V,_row,:),p)
+            begin
+                nrow = size(out, 1)
+                for _row = 1:nrow
+                    __out__row = view(out, _row, :)
+                    __V__row = Dolang._unpack_obs(V, _row)
+                    myfun!($(Dolang.Der{0}),$(Dolang.DISPATCH_ARG)::$(Int), __out__row, __V__row, p)
+                end
+                return out
             end
-            return out
         end
     end))
 
@@ -455,213 +486,110 @@ end
         @test want_d == Dolang.build_function(ffd, Der{0})
         @test want_d! == Dolang.build_function!(ffd, Der{0})
 
-        @test want_vec == Dolang.build_vectorized_function(ff, Der{0})
-        @test want!_vec == Dolang.build_vectorized_function!(ff, Der{0})
-        @test want_d_vec == Dolang.build_vectorized_function(ffd, Der{0})
-        @test want_d!_vec == Dolang.build_vectorized_function!(ffd, Der{0})
-    end
-
-    @testset "  make_method" begin
-        @test make_method(ff) == Expr(:block, want!, want!_vec, want, want_vec)
-        @test make_method(ff; mutating=false) == Expr(:block, want, want_vec)
-        @test make_method(ff; allocating=false) == Expr(:block, want!, want!_vec)
-
-        # test version where you pass args and it makes ff for you
-        have1 = make_method(eqs, args, params, targets=targets, defs=defs,
-                            funname=funname)
-        have2 = make_method(eqs, args, params, targets=targets, defs=defs,
-                            funname=funname, mutating=false)
-        have3 = make_method(eqs, args, params, targets=targets, defs=defs,
-                            funname=funname, allocating=false)
-
-        @test have1 == Expr(:block, want!, want!_vec, want, want_vec)
-        @test have2 == Expr(:block, want, want_vec)
-        @test have3 == Expr(:block, want!, want!_vec)
-
-        # now dispatch version
-        @test make_method(ffd) == Expr(:block, want_d!, want_d!_vec , want_d, want_d_vec)
-        @test make_method(ffd; mutating=false) == Expr(:block, want_d, want_d_vec)
-        @test make_method(ffd; allocating=false) == Expr(:block, want_d!, want_d!_vec)
-
-        # # test version where you pass args and it makes ffd for you
-        have1 = make_method(Int, eqs, args, params, targets=targets, defs=defs,
-                            funname=funname)
-        have2 = make_method(Int, eqs, args, params, targets=targets, defs=defs,
-                            funname=funname, mutating=false)
-        have3 = make_method(Int, eqs, args, params, targets=targets, defs=defs,
-                            funname=funname, allocating=false)
-
-        @test have1 == Expr(:block, want_d!, want_d!_vec, want_d, want_d_vec)
-        @test have2 == Expr(:block, want_d, want_d_vec)
-        @test have3 == Expr(:block, want_d!, want_d!_vec)
-    end
-
-
-    @testset " make_function" begin
-        eqs = [:(a(0)*p^2+b(0))]
-        variables = [(:a, 0), (:b, 0), :p]
-
-        for (to_diff, args, params) in [
-                ([1, 2], [(:a, 0), (:b, 0)], [:p]),
-                ([1], [(:a, 0)], [(:b, 0), :p]),
-                ([1, 3], [(:a, 0), :p], [(:b ,0)])
-            ]
-
-            ff1 = Dolang.FunctionFactory(eqs, args, params)
-            @test ==(
-                Dolang.make_function(eqs, variables, to_diff),
-                Dolang.make_method(ff1, orders=[0, 1])
-            )
-
-            # test orders argument
-            @test ==(
-                Dolang.make_function(eqs, variables, to_diff, orders=[0]),
-                Dolang.make_method(ff1, orders=[0])
-            )
-            @test ==(
-                Dolang.make_function(eqs, variables, to_diff, orders=[0, 1]),
-                Dolang.make_method(ff1, orders=[0, 1])
-            )
-            @test ==(
-                Dolang.make_function(eqs, variables, to_diff, orders=[1]),
-                Dolang.make_method(ff1, orders=[1])
-            )
-            @test ==(
-                Dolang.make_function(eqs, variables, to_diff, orders=[2]),
-                Dolang.make_method(ff1, orders=[2])
-            )
-
-            # test dispatch arugment
-            ff2 = Dolang.FunctionFactory(Int, eqs, args, params)
-            @test ==(
-                Dolang.make_function(eqs, variables, to_diff, dispatch=Int),
-                Dolang.make_method(ff2, orders=[0, 1])
-            )
-
-            # test name argument
-            ff3 = Dolang.FunctionFactory(eqs, args, params, funname=:slick)
-            @test ==(
-                Dolang.make_function(eqs, variables, to_diff, name=:slick),
-                Dolang.make_method(ff3, orders=[0, 1])
-            )
-
-            # test allocating arg
-            @test ==(
-                Dolang.make_function(eqs, variables, to_diff, allocating=false),
-                Dolang.make_method(ff1, orders=[0, 1], allocating=false)
-            )
-
-            # test targets argument
-            eqs2 = eqs = [:(x(0) = a(0)*p^2+b(0))]
-            targets = [(:x, 0)]
-            ff4 = Dolang.FunctionFactory(eqs2, args, params, targets=targets)
-            @test ==(
-                Dolang.make_function(eqs, variables, to_diff, targets=targets),
-                Dolang.make_method(ff4, orders=[0, 1])
-            )
-        end
+        @test want_vec == Dolang.build_vec_function(ff, Der{0})
+        @test want!_vec == Dolang.build_vec_function!(ff, Der{0})
+        @test want_d_vec == Dolang.build_vec_function(ffd, Der{0})
+        @test want_d!_vec == Dolang.build_vec_function!(ffd, Der{0})
     end
 
     @testset " evaluating compiled code" begin
-        eval(current_module(), Dolang.make_method(ff, orders=[0,1,2,3]))
-        u = rand()
-        V = rand(6)+4
-        am, a, b, c, cp, dp = V
-        p = [u]
+        # prep convenience make_function method arguments
+        variables = vcat(args, :u)
+        to_diff = 1:length(args)
+        conv_code = make_function(eqs, variables, to_diff, name=:anon, targets=targets, defs=defs)
+        eval(current_module(), conv_code)
+        eval(current_module(), Dolang.make_function(ff))
+        for (fun, fun!) in [(myfun, myfun!), (anon, anon!)]
+            u = rand()
+            V = rand(6)+4
+            am, a, b, c, cp, dp = V
+            p = [u]
 
-        want = [log(a) + b/(am / (1-c)), cp + u*dp]
-        out = similar(want)
+            want = [log(a) + b/(am / (1-c)), cp + u*dp]
+            out = similar(want)
 
-        # test scalar, allocating version
-        @test want ≈ @inferred myfun(V, p)
-        @test want ≈ @inferred myfun(Dolang.Der{0}, V, p)
+            # test scalar, allocating version
+            @test want ≈ @inferred fun(V, p)
+            @test want ≈ @inferred fun(Dolang.Der{0}, V, p)
 
-        # test scalar, mutating version
-        myfun!(out, V, p)
-        @test want ≈ out
+            # test scalar, mutating version
+            fun!(out, V, p)
+            @test want ≈ out
 
-        myfun!(Dolang.Der{0}, out, V, p)
-        @test want ≈ out
+            fun!(Dolang.Der{0}, out, V, p)
+            @test want ≈ out
 
-        # test vectorized version
-        Vmat = repmat(V', 40, 1)
-        @test maximum(abs, want' .- myfun(Vmat, p)) < 1e-15
-        @test maximum(abs, want' .- myfun(Dolang.Der{0}, Vmat, p)) < 1e-15
+            # test vectorized version
+            Vmat = repmat(V', 40, 1)
+            @test maximum(abs, want' .- fun(Vmat, p)) < 1e-15
+            @test maximum(abs, want' .- fun(Dolang.Der{0}, Vmat, p)) < 1e-15
 
-        # test vectorized mutating version
-        out_mat = Array{Float64}(40, 2)
-        myfun!(out_mat, Vmat, p)
-        @test maximum(abs, want' .- out_mat) < 1e-15
+            # test vectorized mutating version
+            out_mat = Array{Float64}(40, 2)
+            fun!(out_mat, Vmat, p)
+            @test maximum(abs, want' .- out_mat) < 1e-15
 
-        myfun!(Dolang.Der{0}, out_mat, Vmat, p)
-        @test maximum(abs, want' .- out_mat) < 1e-15
+            fun!(Dolang.Der{0}, out_mat, Vmat, p)
+            @test maximum(abs, want' .- out_mat) < 1e-15
 
-        ## Now test derivative code!
-        want = zeros(Float64, 2, 6)
-        want[1, 1] = -1 * b *(1-c)/ (am*am)  # ∂foo/∂am
-        want[1, 2] = 1/a  # ∂foo/∂a
-        want[1, 3] = (1-c) / (am)  # ∂foo/∂b
-        want[1, 4] = -b/am  # ∂foo/∂b
-        want[2, 5] = 1.0  # ∂bar/∂cp
-        want[2, 6] = u # # ∂bar/∂dp
+            ## Now test derivative code!
+            want = zeros(Float64, 2, 6)
+            want[1, 1] = -1 * b *(1-c)/ (am*am)  # ∂foo/∂am
+            want[1, 2] = 1/a  # ∂foo/∂a
+            want[1, 3] = (1-c) / (am)  # ∂foo/∂b
+            want[1, 4] = -b/am  # ∂foo/∂b
+            want[2, 5] = 1.0  # ∂bar/∂cp
+            want[2, 6] = u # # ∂bar/∂dp
 
-        # allocating version
-        @test want ≈ @inferred myfun(Der{1}, V, p)
+            # allocating version
+            @test want ≈ @inferred fun(Der{1}, V, p)
 
-        # non-alocating version
-        out2 = similar(want)
-        myfun!(Der{1}, out2, V, p)
-        @test want ≈ out2
+            # non-alocating version
+            out2 = similar(want)
+            fun!(Der{1}, out2, V, p)
+            @test want ≈ out2
 
-        # and second derivative code
-        want = zeros(Float64, 2, 6*6)
-        want[1, 1]  = 2 * b * (1-c) / (am^3) # ∂²foo/∂am²   = (1,1)
-        want[1, 3]  = -1 *(1-c)/ (am*am)     # ∂²foo/∂am ∂b = (1,3)
-        want[1, 4]  = b /(am^2)              # ∂²foo/∂am ∂c = (1,4)
-        want[1, 8]  = -1/(a^2)               # ∂²foo/∂a²    = (2,2)
-        want[1, 13] = -(1-c)/(am^2)          # ∂²foo/∂b ∂am = (3,1)
-        want[1, 16] = -1/am                  # ∂²foo/∂b ∂c  = (3,4)
-        want[1, 19] = b/(am^2)               # ∂²foo/∂c ∂am = (4,1)
-        want[1, 21] = -1/am                  # ∂²foo/∂c ∂b  = (4,3)
+            # and second derivative code
+            want = zeros(Float64, 2, 6*6)
+            want[1, 1]  = 2 * b * (1-c) / (am^3) # ∂²foo/∂am²   = (1,1)
+            want[1, 3]  = -1 *(1-c)/ (am*am)     # ∂²foo/∂am ∂b = (1,3)
+            want[1, 4]  = b /(am^2)              # ∂²foo/∂am ∂c = (1,4)
+            want[1, 8]  = -1/(a^2)               # ∂²foo/∂a²    = (2,2)
+            want[1, 13] = -(1-c)/(am^2)          # ∂²foo/∂b ∂am = (3,1)
+            want[1, 16] = -1/am                  # ∂²foo/∂b ∂c  = (3,4)
+            want[1, 19] = b/(am^2)               # ∂²foo/∂c ∂am = (4,1)
+            want[1, 21] = -1/am                  # ∂²foo/∂c ∂b  = (4,3)
 
-        @test want ≈ @inferred myfun(Der{2}, V, p)
+            @test want ≈ @inferred fun(Der{2}, V, p)
 
-        # and third derivative code
-        want = [Dict{NTuple{3,Int},Float64}(), Dict{NTuple{3,Int},Float64}()]
-        want[1][(1, 1, 1)] = -6 * b * (1-c) / (am^4) # ∂³foo/∂am³
-        want[1][(1, 1, 3)] = 2 * (1-c) / (am^3)      # ∂³foo/∂am²b
-        want[1][(1, 1, 4)] = -2 * b / (am^3)         # ∂³foo/∂am²c
-        want[1][(2, 2, 2)] = 2/(a^3)                 # ∂³foo/∂a³
-        want[1][(1, 3, 4)] = 1/(am^2)                # ∂³foo / ∂a ∂b ∂c
+            # and third derivative code
+            want = [Dict{NTuple{3,Int},Float64}(), Dict{NTuple{3,Int},Float64}()]
+            want[1][(1, 1, 1)] = -6 * b * (1-c) / (am^4) # ∂³foo/∂am³
+            want[1][(1, 1, 3)] = 2 * (1-c) / (am^3)      # ∂³foo/∂am²b
+            want[1][(1, 1, 4)] = -2 * b / (am^3)         # ∂³foo/∂am²c
+            want[1][(2, 2, 2)] = 2/(a^3)                 # ∂³foo/∂a³
+            want[1][(1, 3, 4)] = 1/(am^2)                # ∂³foo / ∂a ∂b ∂c
 
-        have = @inferred myfun(Der{3}, V, p)
+            have = @inferred fun(Der{3}, V, p)
 
-        @test length(have[1]) == 5
-        @test length(have[2]) == 0
-        for (k, v) in have[1]
-            @show k, v
-            @test v ≈ want[1][k]
+            @test length(have[1]) == 5
+            @test length(have[2]) == 0
+            for (k, v) in have[1]
+                @test v ≈ want[1][k]
+            end
         end
-
-
-
     end
 end
-
-@testset "derivative code runs" begin
-    @test (Dolang.build_function(ff, Der{1}); true)
-    @test (Dolang.build_function(ff, Der{2}); true)
-end  # @testset "derivative code runs"
 
 @testset "issue #14" begin
     eqs = Expr[:(1+a-a)]
     ss_args = Tuple{Symbol,Int64}[(:a,0)]
     p_args = Symbol[:q]
 
+    ff = Dolang.FunctionFactory(eqs, ss_args, p_args, funname=:f_s)
     # just make sure this runs
-    Dolang.make_method(eqs, ss_args, p_args, funname=:f_s, orders=[0, 1])
+    Dolang.func_body(ff, Dolang.Der{2})
 end
 
 
 end  # @testset "compiler"
--

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -628,11 +628,11 @@ end
 
         # and third derivative code
         want = [Dict{NTuple{3,Int},Float64}(), Dict{NTuple{3,Int},Float64}()]
-        want[1][(1,1,1)] = -6 * b * (1-c) / (am^4) # ∂³foo/∂am³
-        want[1][(1,1,3)] = 2 * (1-c) / (am^3)      # ∂³foo/∂am²b
-        want[1][(1,1,4)] = -2 * b / (am^3)         # ∂³foo/∂am²c
-        want[1][(2,2,2)] = 2/(a^3)                 # ∂³foo/∂a³
-        want[1][(1,3,4)] = 1/(am^2)                # ∂³foo / ∂a ∂b ∂c
+        want[1][(1, 1, 1)] = -6 * b * (1-c) / (am^4) # ∂³foo/∂am³
+        want[1][(1, 1, 3)] = 2 * (1-c) / (am^3)      # ∂³foo/∂am²b
+        want[1][(1, 1, 4)] = -2 * b / (am^3)         # ∂³foo/∂am²c
+        want[1][(2, 2, 2)] = 2/(a^3)                 # ∂³foo/∂a³
+        want[1][(1, 3, 4)] = 1/(am^2)                # ∂³foo / ∂a ∂b ∂c
 
         have = @inferred myfun(Der{3}, V, p)
 

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -287,6 +287,10 @@ end
         @test_throws MethodError f(1)        # Number
         @test_throws MethodError f([1])      # Array of number
     end
+
+    @test Dolang.arg_name_time(:_x__1_) == (:x, 1)
+    @test Dolang.arg_name_time(:_x_m100_) == (:x, -100)
+    @test Dolang.arg_name_time(:_this_is_x_m100_) == (:this_is_x, -100)
 end
 
 end  # @testset "symbolic"

--- a/test/util.jl
+++ b/test/util.jl
@@ -75,5 +75,25 @@
         @test Dolang.inf_to_Inf(:(x-inf)) == :(x-$(Inf))
     end
 
+    @testset "solve_triangular_system" begin
+        # very simple case
+        d1 = Dict(:x => 1.0, :y => :(x+1))
+        sol1 = OrderedDict{Symbol,Number}(:x => 1.0, :y => 2.0)
+        @test Dolang.solve_triangular_system(d1) == sol1
+
+        # fully specified numerical dict
+        d2 = Dict(:x => 1.0, :y => 2.0)
+        sol2 = OrderedDict{Symbol,Number}(:x => 1.0, :y => 2.0)
+        @test Dolang.solve_triangular_system(d2) == sol2
+
+        # unknown variable w
+        d3 = Dict(:x => 1.0, :y => :(x+1), :z=> :(100*w))
+        @test_throws ErrorException Dolang.solve_triangular_system(d3)
+
+        # non-triangular system
+        d4 = Dict(:x => :(y+1), :y => :(x-1))
+        @test_throws ErrorException Dolang.solve_triangular_system(d4)
+    end
+
 
 end  # @testset "util"


### PR DESCRIPTION
main highlights:

-  closes #22 : smart generated functions that compute derivative expressions on the fly when the user asks for them
- remove `make_method` in favor of `make_function`, which has been given the smart generated function behavior 
- Allow users to pass mixed vectorized arguments. 